### PR TITLE
Create LICENSE.md to show BSD 3-Clause license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2014, Jelmer Tiete <jelmer@tiete.be>.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Create LICENSE.md to show BSD 3-Clause license used in script header the script to better show license uses.

https://opensource.org/licenses/BSD-3-Clause

Same as https://github.com/JelmerT/cc2538-bsl/pull/117 which was merged as per issue https://github.com/JelmerT/cc2538-bsl/issues/59 for upstream by /cc2538-bsl JelmerT.

LICENSE.md file will also let GitHub users filter the project per license.

![image](https://user-images.githubusercontent.com/6320001/150526937-c362dda4-0114-4bf7-9544-d43265f56c65.png)



